### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+cache: yarn
+node_js:
+  - stable
+  - "6"
+  - "4"
+script:
+  - npm run test
+  - npm run lint


### PR DESCRIPTION
Travis CI is very useful. It runs tests for every commit on its servers (for free!). On any mistake, it will send you an email. As result, it could protect you from releasing bad code.

Also, it will run tests for every pull request so a developer will get feedback even before your review.

It became so popular, so GitHub has good integration for it and even recommend it.

To enable you need do this before accepting PR:

1. Go to https://travis-ci.org/
2. Sign in with GitHub.
3. Press `+` button in the left menu.
4. If you didn’t see your project on this page, press `Sync account`.
5. Enable Travis CI for `smallwins/spacetime`.