### PR TITLE
Add Size Limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ node_js:
 script:
   - npm run test
   - npm run lint
+  - npm run size

--- a/package.json
+++ b/package.json
@@ -11,13 +11,16 @@
     "watch": "node ./scripts/watch.js",
     "test": "./node_modules/tape/bin/tape ./test/**/*.test.js | ./node_modules/tap-spec/bin/cmd.js",
     "lint": "eslint .",
+    "size": "size-limit",
     "coverage": "node ./scripts/coverage.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/smallwins/spacetime.git"
   },
-  "files": ["builds/"],
+  "files": [
+    "builds/"
+  ],
   "dependencies": {},
   "devDependencies": {
     "babel-preset-es2015": "6.9.0",
@@ -33,9 +36,16 @@
     "nyc": "^8.4.0",
     "prettier": "^1.5.3",
     "shelljs": "^0.7.2",
+    "size-limit": "^0.8.0",
     "tap-spec": "4.1.1",
     "tape": "4.6.0",
     "timekeeper": "^1.0.0",
     "uglify-js": "2.7.0"
-  }
+  },
+  "size-limit": [
+    {
+      "path": "builds/spacetime.js",
+      "limit": "11 KB"
+    }
+  ]
 }


### PR DESCRIPTION
It is awesome how small is `spacetime`. But to be always small it is good to have regression protect.

[Size Limit](https://github.com/ai/size-limit) is this protection. On every pull request, Travis CI will execute Size Limit. Size Limit will create in memory empty webpack project and add your library there as the dependency. As result, it will calculate the real cost for your uses of add `spacetime`.

If developer will use `process` in wrong way (so webpack will add huge polyfill) or add an unexpected big dependency, Size Limit will tell you in Travis CI.

Materian UI, MobX, PostCSS and Autoprefixer already use it.

@spencermountain what do you think?