### PR TITLE
Add `from` and `fromNow` methods

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -3,6 +3,7 @@ const format = require('./methods/format')
 const progress = require('./methods/progress')
 const nearest = require('./methods/nearest')
 const diff = require('./methods/diff')
+const from = require('./methods/from')
 const ends = require('./methods/startOf')
 const timezone = require('./timezone/index')
 const handleInput = require('./input')
@@ -50,6 +51,12 @@ const methods = {
   },
   diff: function(d, unit) {
     return diff(this, d, unit)
+  },
+  from: function (d) {
+    return from(this, d)
+  },
+  fromNow: function () {
+    return from(this, this.clone().set())
   },
   isValid: function() {
     return this.valid && !isNaN(this.d.getTime())

--- a/src/methods/from.js
+++ b/src/methods/from.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const secondInMs = 1000;
+const minuteInMs = 60000;
+const hourInMs = 3600000;
+const dayInMs = 86400000;
+
+const qualifiers = {
+  months: { almost: 10, over: 4 },
+  days: { almost: 25, over: 10 },
+  hours: { almost: 20, over: 8 },
+  minutes: { almost: 50, over: 20 },
+  seconds: { almost: 50, over: 20 }
+}
+
+const diffUnits = ['years', 'months', 'days', 'hours', 'minutes', 'seconds'];
+
+function getDiff (a, b) {
+  const { floor } = Math;
+  const isBefore = a.isBefore(b);
+  const earlier = isBefore ? a : b;
+  const later = isBefore ? b : a;
+
+  let totalMonths = later.month() - earlier.month() + (later.year() - earlier.year()) * 12;
+  if (earlier.clone().add(totalMonths, 'months').isAfter(later)) --totalMonths;
+  const milliseconds = +later.d - +(earlier.clone().add(totalMonths, 'months').d);
+
+  const diff = {};
+
+  diff.years = floor(totalMonths / 12);
+  diff.months = totalMonths % 12;
+  diff.days = floor(milliseconds / dayInMs);
+  diff.hours = floor(milliseconds % dayInMs / hourInMs);
+  diff.minutes = floor(milliseconds % dayInMs % hourInMs / minuteInMs);
+  diff.seconds = floor(milliseconds % dayInMs % hourInMs % minuteInMs / secondInMs);
+
+  if (isBefore) diffUnits.forEach(u => diff[u] *= -1);
+
+  return diff;
+}
+
+// Expects a plural unit arg
+function pluralize (value, unit) {
+  if (value === 1) unit = unit.slice(0, -1);
+  return value + ' ' + unit;
+}
+
+const from = (start, end) => {
+  const { abs } = Math;
+  const isStartBeforeEnd = start.isBefore(end);
+  const diff = getDiff(start, end);
+  const isSame = diffUnits.every(u => !diff[u]);
+
+  let rounded;
+  let qualified;
+  let precise;
+  let englishValues = [];
+
+  if (isSame) {
+    rounded = qualified = precise = 'now';
+    return { diff, rounded, qualified, precise };
+  }
+
+  diffUnits.forEach((unit, i, units) => {
+    const value = abs(diff[unit]);
+    if (value === 0) return;
+
+    const englishValue = pluralize(value, unit);
+    englishValues.push(englishValue);
+
+    if (!rounded) {
+      rounded = qualified = englishValue;
+
+      if (i > 4) return;
+      const nextUnit = units[i + 1];
+      const nextValue = abs(diff[nextUnit]);
+      const { almost, over } = qualifiers[nextUnit];
+
+      if (nextValue > almost) {
+        rounded = pluralize(value + 1, unit);
+        qualified = 'almost ' + rounded;
+      }
+      else if (nextValue > over) qualified = 'over ' + englishValue;
+    }
+  });
+
+  precise = englishValues.splice(0, 2).join(', ');
+
+  if (isStartBeforeEnd) {
+    rounded += ' ago';
+    qualified += ' ago';
+    precise += ' ago';
+  } else {
+    rounded = 'in ' + rounded;
+    qualified = 'in ' + qualified;
+    precise = 'in ' + precise;
+  }
+
+  return { diff, rounded, qualified, precise };
+}
+
+module.exports = from;

--- a/test/from.test.js
+++ b/test/from.test.js
@@ -1,0 +1,113 @@
+'use strict';
+const test = require('tape');
+const spacetime = require('./lib');
+
+test('from', t => {
+  const a = spacetime('November 11, 1999 11:11:11', 'Canada/Eastern');
+  const b = spacetime('December 12, 2000 12:12:12', 'Canada/Eastern');
+
+  t.deepEqual(a.from(b), {
+    diff: {
+      years: -1,
+      months: -1,
+      days: -1,
+      hours: -1,
+      minutes: -1,
+      seconds: -1
+    },
+    rounded: '1 year ago',
+    qualified: '1 year ago',
+    precise: '1 year, 1 month ago'
+  }, 'simple-ago')
+
+  t.deepEqual(b.from(a), {
+    diff: {
+      years: 1,
+      months: 1,
+      days: 1,
+      hours: 1,
+      minutes: 1,
+      seconds: 1
+    },
+    rounded: 'in 1 year',
+    qualified: 'in 1 year',
+    precise: 'in 1 year, 1 month'
+  }, 'simple-in')
+
+  t.deepEqual(a.from(a), {
+    diff: {
+      years: 0,
+      months: 0,
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 0
+    },
+    rounded: 'now',
+    qualified: 'now',
+    precise: 'now'
+  }, 'same')
+
+  const almostTwoYears = a.clone().add(1, 'year').add(11, 'months')
+  const overTwoMonths = a.clone().add(2, 'months').add(11, 'days')
+  const yearAndASecond = a.clone().add(1, 'year').add(1, 'second')
+  const twoSeconds = a.clone().add(2, 'seconds')
+
+  t.deepEqual(a.from(almostTwoYears), {
+    diff: {
+      years: -1,
+      months: -11,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -0
+    },
+    rounded: '2 years ago',
+    qualified: 'almost 2 years ago',
+    precise: '1 year, 11 months ago'
+  }, 'almost')
+
+  t.deepEqual(a.from(overTwoMonths), {
+    diff: {
+      years: -0,
+      months: -2,
+      days: -11,
+      hours: -0,
+      minutes: -0,
+      seconds: -0
+    },
+    rounded: '2 months ago',
+    qualified: 'over 2 months ago',
+    precise: '2 months, 11 days ago'
+  }, 'over')
+
+  t.deepEqual(a.from(yearAndASecond), {
+    diff: {
+      years: -1,
+      months: -0,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -1
+    },
+    rounded: '1 year ago',
+    qualified: '1 year ago',
+    precise: '1 year, 1 second ago'
+  }, 'precise')
+
+  t.deepEqual(a.from(twoSeconds), {
+    diff: {
+      years: -0,
+      months: -0,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -2
+    },
+    rounded: '2 seconds ago',
+    qualified: '2 seconds ago',
+    precise: '2 seconds ago'
+  }, 'seconds')
+
+  t.end();
+});

--- a/test/fromNow.test.js
+++ b/test/fromNow.test.js
@@ -1,0 +1,25 @@
+'use strict';
+const test = require('tape');
+const spacetime = require('./lib');
+
+test('fromNow', t => {
+  const past = spacetime.now()
+    .subtract(23, 'months')
+    .subtract(23, 'seconds')
+
+  t.deepEqual(past.fromNow(), {
+    diff: {
+      years: -1,
+      months: -11,
+      days: -0,
+      hours: -0,
+      minutes: -0,
+      seconds: -23
+    },
+    rounded: '2 years ago',
+    qualified: 'almost 2 years ago',
+    precise: '1 year, 11 months ago'
+  }, 'years-ago')
+
+  t.end();
+});


### PR DESCRIPTION
Closes https://github.com/smallwins/spacetime/issues/46

``` javascript
const a = spacetime('November 11, 1999 11:11:11', 'Canada/Eastern');
const b = spacetime('December 12, 2000 12:12:12', 'Canada/Eastern');

a.from(b);
// {
//   diff: {
//     years: -1,
//     months: -1,
//     days: -1,
//     hours: -1,
//     minutes: -1,
//     seconds: -1
//   },
//   rounded: '1 year ago',
//   qualified: '1 year ago',
//   precise: '1 year, 1 month ago'
// }

b.from(a);
// {
//   diff: {
//     years: 1,
//     months: 1,
//     days: 1,
//     hours: 1,
//     minutes: 1,
//     seconds: 1
//   },
//   rounded: 'in 1 year',
//   qualified: 'in 1 year',
//   precise: 'in 1 year, 1 month'
// }
```
``` javascript
const past = spacetime.now()
  .subtract(23, 'months')
  .subtract(23, 'seconds')
  
past.fromNow()
// {
//   diff: {
//     years: -1,
//     months: -11,
//     days: -0,
//     hours: -0,
//     minutes: -0,
//     seconds: -23
//   },
//   rounded: '2 years ago',
//   qualified: 'almost 2 years ago',
//   precise: '1 year, 11 months ago'
// }